### PR TITLE
fix: real HTTP 401, await logout & redirect, document env URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
-NUXT_PUBLIC_HANKO_API_URL=hanko_api_url
+# Hanko API URL — create a project at https://cloud.hanko.io to get yours.
+# Format: https://<project-id>.hanko.io
+# Must be HTTPS in production; http://localhost:<port> is fine for self-hosted dev.
+NUXT_PUBLIC_HANKO_API_URL=

--- a/components/HankoStarterHeader.vue
+++ b/components/HankoStarterHeader.vue
@@ -1,14 +1,15 @@
 <script setup lang="ts">
     import { useRoute } from 'vue-router'
 
-    const route = useRoute()    
+    const route = useRoute()
 
     const hanko = useHanko()
 
     const email = (await hanko?.user.getCurrent())?.email
 
-    function logout() {
-        hanko!.user.logout()
+    async function logout() {
+        await hanko?.user.logout()
+        await navigateTo('/')
     }
 </script>
 
@@ -27,5 +28,5 @@
             <button @click="logout">Sign-Out</button>
         </div>
       </div>
-    </div>  
+    </div>
 </template>

--- a/server/api/endpoint.ts
+++ b/server/api/endpoint.ts
@@ -1,15 +1,19 @@
 export default defineEventHandler(async (event) => {
-    const hanko = event.context.hanko;
-    if (!hanko || !hanko.sub) {
-      return {
-        status: 401,
-        body: {
-          message: "Unauthorized",
-        },
-      };
-    }
-    // Do something with the Hanko user
-    return {
-      hanko: event.context.hanko,
-    };
-  });
+  const hanko = event.context.hanko;
+
+  // Returning `{ status: 401, body: ... }` from a handler does NOT set the
+  // HTTP status code — the client receives a 200 with that JSON as the body.
+  // Use createError() so the response is a real 401.
+  if (!hanko?.sub) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: 'Unauthorized',
+    });
+  }
+
+  return {
+    userId: hanko.sub,
+    email: hanko.email?.address ?? null,
+    sessionExpiresAt: hanko.exp,
+  };
+});


### PR DESCRIPTION
- server/api/endpoint.ts: defineEventHandler ignores `{ status, body }` returned from the handler, so the original sent HTTP 200 with the 401 object in the body. Throw createError({ statusCode: 401 }) so the response is a real HTTP error, and narrow the success payload to the fields a caller actually uses (userId, email, exp).
- components/HankoStarterHeader.vue: make logout() async, await hanko.user.logout() and navigateTo('/') so the originating tab redirects on sign-out instead of sitting on the protected page.
- .env.example: document NUXT_PUBLIC_HANKO_API_URL format and the HTTPS-in-prod requirement instead of the bare placeholder.